### PR TITLE
Add BIND_PATTERN as an alternative login selector

### DIFF
--- a/app.py
+++ b/app.py
@@ -33,7 +33,7 @@ def authenticated( view: Callable):
         if not request.authorization and not app.config['BIND_DN']:
             return quart.Response(
                 'Please log in', 401, UNAUTHORIZED)
-            
+
         try:
             # Set up LDAP connection
             request.ldap = ldap.initialize( app.config['LDAP_URL'])
@@ -42,10 +42,14 @@ def authenticated( view: Callable):
                 dn = app.config['BIND_DN']
                 pw = app.config['BIND_PASSWORD']
 
+            elif app.config['BIND_PATTERN']:
+                dn = app.config['BIND_PATTERN'] % (request.authorization.username)
+                pw = request.authorization.password
+
             else: # Search user in HTTP headers
                 pw = request.authorization.password
                 try:
-                    dn, _attrs = await unique( request.ldap.search( 
+                    dn, _attrs = await unique( request.ldap.search(
                         app.config['BASE_DN'],
                         ldap.SCOPE_SUBTREE,
                         '(%s=%s)' % (app.config['LOGIN_ATTR'], request.authorization.username)))

--- a/settings.py
+++ b/settings.py
@@ -20,10 +20,11 @@ LOGIN_ATTR = os.environ.get( 'LOGIN_ATTR', 'uid')
 # You need to secure it otherwise!
 BIND_DN = os.environ.get( 'BIND_DN')
 BIND_PASSWORD = os.environ.get( 'BIND_PASSWORD')
+BIND_PATTERN = os.environ.get('BIND_PATTERN')
 
 # Searches
 SEARCH_PATTERNS = ( # for search field
-    '(%s=%%s)' % LOGIN_ATTR, 
+    '(%s=%%s)' % LOGIN_ATTR,
     '(cn=%s)',
     '(gn=%s)',
     '(sn=%s)',


### PR DESCRIPTION
Using the configuration setting `BIND_PATTERN` allows to define a string that's going to be used for the bind, e.g. `uid=%s,ou=people,dc=example,dc=com`, which works even when unauthenticated users cannot do a search for the user object.