### PR TITLE
Support docker secrets with BIND_PASSWORD_FILE

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -21,6 +21,11 @@ LOGIN_ATTR = os.environ.get('LOGIN_ATTR', 'uid')
 # You need to secure it otherwise!
 BIND_DN = os.environ.get('BIND_DN')
 BIND_PASSWORD = os.environ.get('BIND_PASSWORD')
+if BIND_PASSWORD is None:
+    PW_FILE = os.environ.get('BIND_PASSWORD_FILE')
+    if PW_FILE is not None:
+        with open(PW_FILE) as file:
+            BIND_PASSWORD = file.read().rstrip('\n')
 
 # Optional user DN pattern string for authentication,
 # e.g. "uid=%s,ou=people,dc=example,dc=com".


### PR DESCRIPTION
If the environment variable `BIND_PASSWORD` is set, `BIND_PASSWORD_FILE` will be ignored, otherwise it will try to load password from that password file. 

This feature can be used like this in docker-compose:

```yml
---
version: "3.8"

secrets:
  ldap-password:
    file: ./ldap_admin_password_file

services:
  ldap-ui:
    image: dnknth/ldap-ui
    secrets:
      - ldap-password
    environment:
      - LDAP_URL=ldap://openldap/
      - BASE_DN=${BASE_DN}
      - BIND_DN=cn=admin,${BASE_DN}
      - BIND_PASSWORD_FILE=/run/secrets/ldap-password
    ports:
      - "5000:5000"
```