### PR TITLE
Send StartTLS before binding

### DIFF
--- a/backend/ldap_ui/ldap_api.py
+++ b/backend/ldap_ui/ldap_api.py
@@ -113,6 +113,15 @@ async def ldap_connect() -> Connection:
     url, base_dn = parse_url(settings.LDAP_URL)
     server = Server(url, get_info=ALL)
     connection = Connection(server, client_strategy=ASYNC, raise_exceptions=True)
+
+    # Negotiate StartTLS before binding. Otherwise the bind and the root DSE
+    # lookup below are sent in clear text, and directories that mandate
+    # confidentiality (e.g. OpenLDAP `olcSecurity: tls=1`) reject every
+    # operation attempted before TLS is in place. See RFC 4513, §3.1.1.
+    if settings.USE_TLS and url.startswith("ldap://"):
+        connection.open(read_server_info=False)
+        connection.start_tls()
+
     connection.bind()
     dsa_info = connection.server.info
 
@@ -130,9 +139,6 @@ async def ldap_connect() -> Connection:
     if not settings.SCHEMA_DN:
         assert dsa_info.schema_entry, "Cannot determine LDAP schema"
         settings.SCHEMA_DN = dsa_info.schema_entry[0]
-
-    if settings.USE_TLS and url.startswith("ldap://"):
-        connection.start_tls()
 
     return connection
 

--- a/tests/connection_test.py
+++ b/tests/connection_test.py
@@ -1,0 +1,59 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from ldap_ui import ldap_api, settings
+
+
+class StartTlsOrderingTest(unittest.IsolatedAsyncioTestCase):
+    """`ldap_connect()` must negotiate StartTLS before it binds.
+
+    Binding first would expose the bind and the root DSE lookup in clear
+    text, and directories that require confidentiality (e.g. OpenLDAP
+    `olcSecurity: tls=1`) reject any operation attempted before TLS is in
+    place. See RFC 4513, §3.1.1 (StartTLS Request Sequencing).
+    """
+
+    async def _operation_order(self, ldap_url: str) -> list[str]:
+        "Record the order of connection operations for the given URL."
+
+        order: list[str] = []
+        connection = MagicMock(name="Connection")
+        for op in ("open", "start_tls", "bind"):
+            getattr(connection, op).side_effect = (
+                lambda *args, _op=op, **kwargs: order.append(_op)
+            )
+
+        # Pin BASE_DN/SCHEMA_DN so the root DSE auto-detection is skipped and
+        # the test stays focused on the connection setup sequence.
+        with (
+            patch.object(ldap_api, "Server"),
+            patch.object(ldap_api, "Connection", return_value=connection),
+            patch.object(settings, "LDAP_URL", ldap_url),
+            patch.object(settings, "USE_TLS", True),
+            patch.object(settings, "BASE_DN", "o=Flintstones"),
+            patch.object(settings, "SCHEMA_DN", "cn=Subschema"),
+        ):
+            await ldap_api.ldap_connect()
+
+        return order
+
+    async def test_starttls_precedes_bind(self):
+        order = await self._operation_order("ldap://ldap.example.com")
+        self.assertIn("start_tls", order, "StartTLS was not negotiated")
+        self.assertIn("bind", order)
+        self.assertLess(
+            order.index("start_tls"),
+            order.index("bind"),
+            "bind() must not run before StartTLS is established",
+        )
+
+    async def test_ldaps_skips_starttls(self):
+        # ldaps:// is wrapped in TLS from the first byte, so an explicit
+        # StartTLS would be a protocol error.
+        order = await self._operation_order("ldaps://ldap.example.com")
+        self.assertNotIn("start_tls", order)
+        self.assertIn("bind", order)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`ldap_connect()` binds the connection and reads the root DSE before it upgrades
to StartTLS, so the anonymous bind and the DSE lookup go out in clear text even
when `USE_TLS` is set. This PR negotiates StartTLS before the bind instead.

### Why

The `python-ldap` backend used to call `start_tls_s()` right after
`initialize()`, before any bind. The `ldap3` rewrite in 0.13.0 reordered it so
the bind now runs first:

```python
connection = Connection(server, client_strategy=ASYNC, raise_exceptions=True)
connection.bind()                     # clear text
dsa_info = connection.server.info     # clear text
...
if settings.USE_TLS and url.startswith("ldap://"):
    connection.start_tls()            # too late
```

RFC 4513 §3.1.1 ("StartTLS Request Sequencing") recommends the opposite:

> where a client intends to perform both a Bind operation and a StartTLS
> operation, it SHOULD first perform the StartTLS operation so that the Bind
> request and response messages are protected by the data security services
> established by the StartTLS operation.

On a directory that requires confidentiality this breaks the whole UI. An
OpenLDAP server with `olcSecurity: tls=1` rejects the initial bind with
`confidentialityRequired (13)`, so `/api/whoami`, `/api/tree/base` and
`/api/schema` all return HTTP 500. On servers that accept the early bind, the
credentials and directory contents are still exposed on the wire even though
`USE_TLS` is enabled.

### Fix

```python
if settings.USE_TLS and url.startswith("ldap://"):
    connection.open(read_server_info=False)
    connection.start_tls()

connection.bind()
```

`open(read_server_info=False)` avoids fetching the root DSE in clear text before
the handshake; the server info is read afterwards over TLS, so base-DN and
schema-DN auto-detection still work. `ldaps://` is untouched (already wrapped in
TLS), and connections with `USE_TLS` unset behave as before.

### Tests

`tests/connection_test.py` is added. It runs offline (no live server) and checks
that StartTLS is negotiated before the bind for `ldap://`, and that `ldaps://`
does not issue a redundant StartTLS.

```
uv run python -m unittest tests.connection_test
```
